### PR TITLE
Normalize doc comments

### DIFF
--- a/src/archive_old_data.py
+++ b/src/archive_old_data.py
@@ -1,11 +1,13 @@
 """
-General Cleaner Script for Landing and Raw Zones
-
-Moves older copies of data files (older than 7 days) to the archive zone, appending [ARCHIVED ON (datetime)] to the filename.
-
-- Scans landing and raw zones recursively
-- For files with the same base identity (e.g., same prefix or matching pattern), keeps the newest and archives older ones
-- Archive files are renamed to include the archive date
+/// General Cleaner Script for Landing and Raw Zones.
+///
+/// Moves older copies of data files (older than 7 days) to the archive zone,
+/// appending [ARCHIVED ON (datetime)] to the filename.
+///
+/// - Scans landing and raw zones recursively.
+/// - For files with the same base identity (e.g., same prefix or matching
+///   pattern), keeps the newest and archives older ones.
+/// - Archive files are renamed to include the archive date.
 """
 import os
 import shutil

--- a/src/common/cookies.py
+++ b/src/common/cookies.py
@@ -1,13 +1,15 @@
-"""Shared utilities for Playwright cookie/session handling.
-
-This module provides two helpers – ``load_cookies`` and ``load_cookies_async`` – 
-which load one or more cookie JSON files from ``src/<service>/cookies`` into 
-the provided Playwright *persistent* ``browser_context``.  It ensures:
-
-1. **One-time import** per ``user_data_dir`` to avoid duplicate cookies.
-2. **sameSite sanitisation** – invalid values coerced to "Lax" so Playwright
-   will accept the cookie.
-3. **Graceful no-op** when no cookie files are present.
+"""
+/// Shared utilities for Playwright cookie/session handling.
+///
+/// This module provides two helpers – ``load_cookies`` and
+/// ``load_cookies_async`` – which load one or more cookie JSON files from
+/// ``src/<service>/cookies`` into the provided Playwright *persistent*
+/// ``browser_context``. It ensures:
+///
+/// 1. **One-time import** per ``user_data_dir`` to avoid duplicate cookies.
+/// 2. **sameSite sanitisation** – invalid values coerced to "Lax" so Playwright
+///    will accept the cookie.
+/// 3. **Graceful no-op** when no cookie files are present.
 
 Example
 -------
@@ -52,7 +54,7 @@ _VALID_SAMESITE: set[str] = {"Strict", "Lax", "None"}
 
 
 def _resolve_cookie_dir(service: str) -> Path:
-    """Return path to ``src/<service>/cookies`` (create if missing)."""
+    """/// Return path to ``src/<service>/cookies`` (create if missing)."""
     root = Path(__file__).resolve().parents[1]
     cookie_dir = root / service / "cookies"
     cookie_dir.mkdir(parents=True, exist_ok=True)
@@ -60,7 +62,7 @@ def _resolve_cookie_dir(service: str) -> Path:
 
 
 def _get_marker_path(context, service: str) -> Path:
-    """Return a marker-file path scoped to *context*'s user_data_dir."""
+    """/// Return a marker-file path scoped to *context*'s user_data_dir."""
     # The attr name differs between sync / async contexts; fall back to cwd.
     user_data_dir = getattr(context, "_user_data_dir", None)
     if not user_data_dir:
@@ -88,7 +90,7 @@ def _collect_cookie_dicts(cookie_dir: Path) -> List[Dict[str, Any]]:
 
 
 def load_cookies(context, service_name: str) -> None:
-    """Inject cookies into *context* **once** per user_data_dir.
+    """/// Inject cookies into *context* **once** per user_data_dir.
 
     Parameters
     ----------
@@ -118,7 +120,8 @@ def load_cookies(context, service_name: str) -> None:
 
 
 async def load_cookies_async(context, service_name: str) -> None:
-    """Asynchronous variant of ``load_cookies`` for Playwright ``async_api`` contexts."""
+    """/// Asynchronous variant of ``load_cookies`` for Playwright
+    /// ``async_api`` contexts."""
     cookie_dir = _resolve_cookie_dir(service_name)
     marker_path = _get_marker_path(context, service_name)
 

--- a/src/distrokid/extractors/dk_auth.py
+++ b/src/distrokid/extractors/dk_auth.py
@@ -32,9 +32,10 @@ DK_PASSWORD = os.getenv("DK_PASSWORD")
 
 def login_distrokid():
     """
-    Automates login to DistroKid, including 2FA, and persists session for future use.
-    Credentials are read from environment variables DK_EMAIL and DK_PASSWORD.
-    If 2FA is required, user will be prompted to enter the code manually in the browser.
+    /// Automates login to DistroKid, including 2FA, and persists session for
+    /// future use. Credentials are read from environment variables DK_EMAIL and
+    /// DK_PASSWORD. If 2FA is required, the user will be prompted to enter the
+    /// code manually in the browser.
     """
     if not DK_EMAIL or not DK_PASSWORD:
         logging.error("DK_EMAIL and DK_PASSWORD must be set in environment variables or .env file.")
@@ -134,7 +135,8 @@ def login_distrokid():
 
 def test_login_distrokid():
     """
-    Test to verify if the login session is valid and can access the stats page without manual intervention.
+    /// Test to verify if the login session is valid and can access the stats
+    /// page without manual intervention.
     """
     with sync_playwright() as p:
         try:

--- a/src/linktree/cleaners/linktree_landing2raw.py
+++ b/src/linktree/cleaners/linktree_landing2raw.py
@@ -1,8 +1,8 @@
 """
-linktree_landing2raw.py
-Landing → Raw cleaner for Linktree data.
-
-Guided by `LLM_cleaner_guidelines.md`.
+/// linktree_landing2raw.py
+/// Landing → Raw cleaner for Linktree data.
+///
+/// Guided by `LLM_cleaner_guidelines.md`.
 """
 
 import os, json, argparse

--- a/src/linktree/cleaners/linktree_raw2staging.py
+++ b/src/linktree/cleaners/linktree_raw2staging.py
@@ -1,15 +1,15 @@
 """
-linktree_raw2staging.py
-Raw → Staging cleaner for Linktree NDJSON data.
-
-Guided by `LLM_cleaner_guidelines.md`.
-• Reads every *.ndjson in raw/linktree/
-• Cleans & deduplicates rows
-• Writes a single UTF-8 CSV file to staging/linktree/
-
-Run:
-    python src/linktree/cleaners/linktree_raw2staging.py
-    python src/linktree/cleaners/linktree_raw2staging.py --out /custom/path/file.csv
+/// linktree_raw2staging.py
+/// Raw → Staging cleaner for Linktree NDJSON data.
+///
+/// Guided by `LLM_cleaner_guidelines.md`.
+/// • Reads every *.ndjson in raw/linktree/
+/// • Cleans & deduplicates rows
+/// • Writes a single UTF-8 CSV file to staging/linktree/
+///
+/// Run:
+///     python src/linktree/cleaners/linktree_raw2staging.py
+///     python src/linktree/cleaners/linktree_raw2staging.py --out /custom/path/file.csv
 """
 
 import os
@@ -39,8 +39,8 @@ METRIC_COLS = [
 
 def record_to_row(rec: dict) -> dict | None:
     """
-    Validate & convert a single JSON record.
-    Returns a dict or None (when 'date' is missing).
+    /// Validate & convert a single JSON record.
+    /// Returns a dict or None (when 'date' is missing).
     """
     if "date" not in rec:
         return None
@@ -53,11 +53,13 @@ def record_to_row(rec: dict) -> dict | None:
 def extract_timeseries_rows(obj: dict) -> list[dict]:
     """Given a JSON object from NDJSON, return a list of flattened rows.
 
-    Scenarios handled:
-    1. Object **already** represents a flattened row (has top-level "date"). Return [obj].
-    2. Object is a full GraphQL payload with structure data→getAccountAnalytics→overview→timeseries.
-       Return list of flattened dicts extracted from the timeseries array.
-    3. Any other structure → returns empty list.
+    /// Scenarios handled:
+    /// 1. Object **already** represents a flattened row (has top-level
+    ///    "date"). Return [obj].
+    /// 2. Object is a full GraphQL payload with structure
+    ///    data→getAccountAnalytics→overview→timeseries. Return list of
+    ///    flattened dicts extracted from the timeseries array.
+    /// 3. Any other structure → returns empty list.
     """
     # Case 1 – already flattened
     if "date" in obj:

--- a/src/linktree/cleaners/linktree_staging2curated.py
+++ b/src/linktree/cleaners/linktree_staging2curated.py
@@ -1,9 +1,9 @@
 """
-linktree_staging2curated.py
-Staging → Curated cleaner for Linktree analytics.
-
-Guided by `LLM_cleaner_guidelines.md`.
-Reads **CSV** from staging, writes **CSV and Parquet** to curated.
+/// linktree_staging2curated.py
+/// Staging → Curated cleaner for Linktree analytics.
+///
+/// Guided by `LLM_cleaner_guidelines.md`.
+/// Reads **CSV** from staging, writes **CSV and Parquet** to curated.
 """
 
 import os, argparse

--- a/src/linktree/extractors/linktree_analytics_extractor.py
+++ b/src/linktree/extractors/linktree_analytics_extractor.py
@@ -26,7 +26,8 @@ OUTPUT_DIR = Path(PROJECT_ROOT) / 'landing' / 'linktree' / 'analytics'
 OUTPUT_DIR.mkdir(parents=True, exist_ok=True)
 
 def _click_with_retry(page, selector: str, retries: int = 3, wait_state="visible"):
-    """Attempt to click the FIRST matching element with retries and wait for it to be ready."""
+    """/// Attempt to click the FIRST matching element with retries and wait
+    /// for it to be ready."""
     for attempt in range(retries):
         try:
             locator = page.locator(selector).first

--- a/src/metaads/cleaners/metaads_raw2staging.py
+++ b/src/metaads/cleaners/metaads_raw2staging.py
@@ -20,7 +20,7 @@ folders  = [d for d in raw_meta.iterdir() if d.is_dir()]
 assert folders, f"No raw dumps found in {raw_meta}"
 
 def stack(folders, fname):
-    """Load a JSON file type from every folder, concat, and deduplicate."""
+    """/// Load a JSON file type from every folder, concat, and deduplicate."""
     dfs = [pd.read_json(f / fname, dtype_backend="pyarrow") for f in folders if (f / fname).exists()]
     if not dfs:
         return pd.DataFrame()

--- a/src/metaads/extractors/meta_raw_dump.py
+++ b/src/metaads/extractors/meta_raw_dump.py
@@ -86,8 +86,8 @@ INSIGHT_FIELDS = [
 # ╚════════════════════════════════════════════════════════════════╝
 def fetch_all(edge_method, fields, params=None):
     """
-    Call edge_method (e.g. account.get_campaigns) then auto-page through results.
-    Returns a list of fully-expanded dicts ready for JSON dump.
+    /// Call edge_method (e.g. account.get_campaigns) then auto-page through
+    /// results. Returns a list of fully-expanded dicts ready for JSON dump.
     """
     params   = params or {}
     cursor   = edge_method(fields=fields, params=params)


### PR DESCRIPTION
## Summary
- wrap long docstrings at 80 columns
- add triple-slash comment markers for documentation

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_684b28639d248327832ec98ce237c875